### PR TITLE
add missing catkin_package function call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,12 @@ generate_messages(
   geometry_msgs
 )
 
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package()
+
 ###########
 ## Build ##
 ###########


### PR DESCRIPTION
The catkin_package function generates configuration files for CMake so that other packages can include this package.
